### PR TITLE
fix: repository setup Helm path

### DIFF
--- a/.github/workflows/repository-setup.yml
+++ b/.github/workflows/repository-setup.yml
@@ -91,11 +91,6 @@ jobs:
           rm -rf ./cookiecutter-temp/
           shopt -u dotglob
 
-      - name: Clean up template folders
-        shell: bash
-        run: |
-          rm -rf charts/ deploy/ application/ appcode/ gitops-repo/ rbac/ workflow/ shared-lib/
-
       - name: Update Helm dependencies
         run: |
           helm dependency update ./charts/gitops

--- a/gitops-repo/{{cookiecutter.app_name}}-gitops/.github/workflows/repository-setup.yml
+++ b/gitops-repo/{{cookiecutter.app_name}}-gitops/.github/workflows/repository-setup.yml
@@ -92,11 +92,6 @@ jobs:
           rm -rf ./cookiecutter-temp/
           shopt -u dotglob
 
-      - name: Clean up template folders
-        shell: bash
-        run: |
-          rm -rf charts/ deploy/ application/ appcode/ gitops-repo/ rbac/ workflow/ shared-lib/
-
       - name: Update Helm dependencies
         run: |
           helm dependency update ./charts/gitops


### PR DESCRIPTION
Stop deleting generated charts before running helm dependency update in repository-setup workflow (root + cookiecutter template).